### PR TITLE
Update asset apps to go 1.6.2

### DIFF
--- a/assets/apps/humperdink/Godeps/Godeps.json
+++ b/assets/apps/humperdink/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6.2",
 	"Deps": []
 }

--- a/assets/apps/max/Godeps/Godeps.json
+++ b/assets/apps/max/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6.2",
 	"Deps": []
 }

--- a/assets/apps/princess/Godeps/Godeps.json
+++ b/assets/apps/princess/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6.2",
 	"Deps": []
 }

--- a/assets/apps/westley/Godeps/Godeps.json
+++ b/assets/apps/westley/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
 	"ImportPath": "go-online",
-	"GoVersion": "go1.4.2",
+	"GoVersion": "go1.6.2",
 	"Deps": []
 }


### PR DESCRIPTION
The current [buildpack](github.com/cloudfoundry/go-buildpack/releases) we use does not support go1.4.2 anymore. So we upgraded the GoVersion to go1.6.2
