### PR TITLE
Add options to arborist and cedar to use SSL and ignore certificates

### DIFF
--- a/arborist/main.go
+++ b/arborist/main.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	requestInterval = flag.Duration("request-interval", 1*time.Minute, "interval in seconds at which to make requests to each individual app")
-	duration        = flag.Duration("duration", 10*time.Minute, "total duration to check routability of applications")
-	appFile         = flag.String("app-file", "", "path to json application file")
-	resultFile      = flag.String("result-file", "output.json", "path to result file")
+	requestInterval       = flag.Duration("request-interval", 1*time.Minute, "interval in seconds at which to make requests to each individual app")
+	duration              = flag.Duration("duration", 10*time.Minute, "total duration to check routability of applications")
+	appFile               = flag.String("app-file", "", "path to json application file")
+	resultFile            = flag.String("result-file", "output.json", "path to result file")
+	skipVerifyCertificate = flag.Bool("skip-verify-certificate", false, "whether to ignore invalid TLS certificates")
 )
 
 func main() {
@@ -41,7 +42,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	results, err := watcher.CheckRoutability(logger, clock, applications, *duration, *requestInterval)
+	results, err := watcher.CheckRoutability(logger, clock, applications, *duration, *requestInterval, *skipVerifyCertificate)
 	if err != nil {
 		// This should be impossible
 		logger.Error("failed-to-check-routability", err)

--- a/arborist/watcher/watcher_test.go
+++ b/arborist/watcher/watcher_test.go
@@ -52,6 +52,10 @@ var _ = Describe("Watcher", func() {
 
 	})
 
+	AfterEach(func() {
+		server.Close()
+	})
+
 	Context("when the requests are handled successfully", func() {
 		var (
 			app1Requests = 0
@@ -81,7 +85,7 @@ var _ = Describe("Watcher", func() {
 			go func() {
 				defer GinkgoRecover()
 
-				result, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval)
+				result, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo(map[string]watcher.Result{
 					"app-1-guid": watcher.Result{
@@ -145,7 +149,7 @@ var _ = Describe("Watcher", func() {
 			go func() {
 				defer GinkgoRecover()
 
-				result, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval)
+				result, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval, false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(BeEquivalentTo(map[string]watcher.Result{
 					"app-1-guid": watcher.Result{
@@ -206,7 +210,7 @@ var _ = Describe("Watcher", func() {
 			go func() {
 				defer GinkgoRecover()
 
-				_, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval)
+				_, err := watcher.CheckRoutability(logger, fakeClock, applications, duration, interval, false)
 				Expect(err).NotTo(HaveOccurred())
 				close(done)
 			}()

--- a/cedar/config/config.go
+++ b/cedar/config/config.go
@@ -25,6 +25,8 @@ type Config interface {
 	AppPayload() string
 	Prefix() string
 	Domain() string
+	UseSSL() bool
+	SkipVerifyCertificate() bool
 	// ConfigFile() string
 	OutputFile() string
 	Timeout() time.Duration
@@ -34,16 +36,18 @@ type Config interface {
 }
 
 type config struct {
-	numBatches       int
-	maxInFlight      int
-	maxPollingErrors int
-	tolerance        float64
-	domain           string
-	appPayload       string
-	prefix           string
-	configFile       string
-	outputFile       string
-	timeout          time.Duration
+	numBatches            int
+	maxInFlight           int
+	maxPollingErrors      int
+	tolerance             float64
+	domain                string
+	useSSL                bool
+	skipVerifyCertificate bool
+	appPayload            string
+	prefix                string
+	configFile            string
+	outputFile            string
+	timeout               time.Duration
 
 	appTypes []AppDefinition
 }
@@ -55,18 +59,21 @@ func NewConfig(
 	tolerance float64,
 	appPayload, prefix, domain, configFile, outputFile string,
 	timeout time.Duration,
+	useSSL, skipVerifyCertificate bool,
 ) (Config, error) {
 	c := &config{
-		numBatches:       numBatches,
-		maxInFlight:      maxInFlight,
-		maxPollingErrors: maxPollingErrors,
-		tolerance:        tolerance,
-		appPayload:       appPayload,
-		prefix:           prefix,
-		domain:           domain,
-		configFile:       configFile,
-		outputFile:       outputFile,
-		timeout:          timeout,
+		numBatches:            numBatches,
+		maxInFlight:           maxInFlight,
+		maxPollingErrors:      maxPollingErrors,
+		tolerance:             tolerance,
+		appPayload:            appPayload,
+		prefix:                prefix,
+		domain:                domain,
+		useSSL:                useSSL,
+		skipVerifyCertificate: skipVerifyCertificate,
+		configFile:            configFile,
+		outputFile:            outputFile,
+		timeout:               timeout,
 	}
 	err := c.init(logger, cfClient)
 	if err != nil {
@@ -77,6 +84,14 @@ func NewConfig(
 
 func (c *config) Domain() string {
 	return c.domain
+}
+
+func (c *config) UseSSL() bool {
+	return c.useSSL
+}
+
+func (c *config) SkipVerifyCertificate() bool {
+	return c.skipVerifyCertificate
 }
 
 func (c *config) AppTypes() []AppDefinition {

--- a/cedar/config/config_test.go
+++ b/cedar/config/config_test.go
@@ -20,6 +20,8 @@ var _ = Describe("Cedar", func() {
 		tolerance                                          float64
 		domain, appPayload, prefix, configFile, outputFile string
 		timeout                                            time.Duration
+		useSSL                                             bool
+		skipVerifyCertificate                              bool
 	)
 
 	BeforeEach(func() {
@@ -28,6 +30,8 @@ var _ = Describe("Cedar", func() {
 		maxPollingErrors = 1
 		tolerance = 0.5
 		domain = "bosh-lite.com"
+		useSSL = false
+		skipVerifyCertificate = false
 		appPayload = "assets/temp-app"
 		prefix = "cedarapp"
 		configFile = fakeConfigFile
@@ -44,6 +48,8 @@ var _ = Describe("Cedar", func() {
 			tolerance,
 			appPayload, prefix, domain, configFile, outputFile,
 			timeout,
+			useSSL,
+			skipVerifyCertificate,
 		)
 	})
 

--- a/cedar/config/fakes/fake_config.go
+++ b/cedar/config/fakes/fake_config.go
@@ -45,6 +45,18 @@ type FakeConfig struct {
 	domainReturns     struct {
 		result1 string
 	}
+	UseSSLStub        func() bool
+	useSSLMutex       sync.RWMutex
+	useSSLArgsForCall []struct{}
+	useSSLReturns     struct {
+		result1 bool
+	}
+	SkipVerifyCertificateStub        func() bool
+	skipVerifyCertificateMutex       sync.RWMutex
+	skipVerifyCertificateArgsForCall []struct{}
+	skipVerifyCertificateReturns     struct {
+		result1 bool
+	}
 	OutputFileStub        func() string
 	outputFileMutex       sync.RWMutex
 	outputFileArgsForCall []struct{}
@@ -86,9 +98,8 @@ func (fake *FakeConfig) NumBatches() int {
 	fake.numBatchesMutex.Unlock()
 	if fake.NumBatchesStub != nil {
 		return fake.NumBatchesStub()
-	} else {
-		return fake.numBatchesReturns.result1
 	}
+	return fake.numBatchesReturns.result1
 }
 
 func (fake *FakeConfig) NumBatchesCallCount() int {
@@ -111,9 +122,8 @@ func (fake *FakeConfig) MaxInFlight() int {
 	fake.maxInFlightMutex.Unlock()
 	if fake.MaxInFlightStub != nil {
 		return fake.MaxInFlightStub()
-	} else {
-		return fake.maxInFlightReturns.result1
 	}
+	return fake.maxInFlightReturns.result1
 }
 
 func (fake *FakeConfig) MaxInFlightCallCount() int {
@@ -136,9 +146,8 @@ func (fake *FakeConfig) MaxPollingErrors() int {
 	fake.maxPollingErrorsMutex.Unlock()
 	if fake.MaxPollingErrorsStub != nil {
 		return fake.MaxPollingErrorsStub()
-	} else {
-		return fake.maxPollingErrorsReturns.result1
 	}
+	return fake.maxPollingErrorsReturns.result1
 }
 
 func (fake *FakeConfig) MaxPollingErrorsCallCount() int {
@@ -161,9 +170,8 @@ func (fake *FakeConfig) AppPayload() string {
 	fake.appPayloadMutex.Unlock()
 	if fake.AppPayloadStub != nil {
 		return fake.AppPayloadStub()
-	} else {
-		return fake.appPayloadReturns.result1
 	}
+	return fake.appPayloadReturns.result1
 }
 
 func (fake *FakeConfig) AppPayloadCallCount() int {
@@ -186,9 +194,8 @@ func (fake *FakeConfig) Prefix() string {
 	fake.prefixMutex.Unlock()
 	if fake.PrefixStub != nil {
 		return fake.PrefixStub()
-	} else {
-		return fake.prefixReturns.result1
 	}
+	return fake.prefixReturns.result1
 }
 
 func (fake *FakeConfig) PrefixCallCount() int {
@@ -211,9 +218,8 @@ func (fake *FakeConfig) Domain() string {
 	fake.domainMutex.Unlock()
 	if fake.DomainStub != nil {
 		return fake.DomainStub()
-	} else {
-		return fake.domainReturns.result1
 	}
+	return fake.domainReturns.result1
 }
 
 func (fake *FakeConfig) DomainCallCount() int {
@@ -229,6 +235,54 @@ func (fake *FakeConfig) DomainReturns(result1 string) {
 	}{result1}
 }
 
+func (fake *FakeConfig) UseSSL() bool {
+	fake.useSSLMutex.Lock()
+	fake.useSSLArgsForCall = append(fake.useSSLArgsForCall, struct{}{})
+	fake.recordInvocation("UseSSL", []interface{}{})
+	fake.useSSLMutex.Unlock()
+	if fake.UseSSLStub != nil {
+		return fake.UseSSLStub()
+	}
+	return fake.useSSLReturns.result1
+}
+
+func (fake *FakeConfig) UseSSLCallCount() int {
+	fake.useSSLMutex.RLock()
+	defer fake.useSSLMutex.RUnlock()
+	return len(fake.useSSLArgsForCall)
+}
+
+func (fake *FakeConfig) UseSSLReturns(result1 bool) {
+	fake.UseSSLStub = nil
+	fake.useSSLReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeConfig) SkipVerifyCertificate() bool {
+	fake.skipVerifyCertificateMutex.Lock()
+	fake.skipVerifyCertificateArgsForCall = append(fake.skipVerifyCertificateArgsForCall, struct{}{})
+	fake.recordInvocation("SkipVerifyCertificate", []interface{}{})
+	fake.skipVerifyCertificateMutex.Unlock()
+	if fake.SkipVerifyCertificateStub != nil {
+		return fake.SkipVerifyCertificateStub()
+	}
+	return fake.skipVerifyCertificateReturns.result1
+}
+
+func (fake *FakeConfig) SkipVerifyCertificateCallCount() int {
+	fake.skipVerifyCertificateMutex.RLock()
+	defer fake.skipVerifyCertificateMutex.RUnlock()
+	return len(fake.skipVerifyCertificateArgsForCall)
+}
+
+func (fake *FakeConfig) SkipVerifyCertificateReturns(result1 bool) {
+	fake.SkipVerifyCertificateStub = nil
+	fake.skipVerifyCertificateReturns = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeConfig) OutputFile() string {
 	fake.outputFileMutex.Lock()
 	fake.outputFileArgsForCall = append(fake.outputFileArgsForCall, struct{}{})
@@ -236,9 +290,8 @@ func (fake *FakeConfig) OutputFile() string {
 	fake.outputFileMutex.Unlock()
 	if fake.OutputFileStub != nil {
 		return fake.OutputFileStub()
-	} else {
-		return fake.outputFileReturns.result1
 	}
+	return fake.outputFileReturns.result1
 }
 
 func (fake *FakeConfig) OutputFileCallCount() int {
@@ -261,9 +314,8 @@ func (fake *FakeConfig) Timeout() time.Duration {
 	fake.timeoutMutex.Unlock()
 	if fake.TimeoutStub != nil {
 		return fake.TimeoutStub()
-	} else {
-		return fake.timeoutReturns.result1
 	}
+	return fake.timeoutReturns.result1
 }
 
 func (fake *FakeConfig) TimeoutCallCount() int {
@@ -286,9 +338,8 @@ func (fake *FakeConfig) TotalAppCount() int {
 	fake.totalAppCountMutex.Unlock()
 	if fake.TotalAppCountStub != nil {
 		return fake.TotalAppCountStub()
-	} else {
-		return fake.totalAppCountReturns.result1
 	}
+	return fake.totalAppCountReturns.result1
 }
 
 func (fake *FakeConfig) TotalAppCountCallCount() int {
@@ -311,9 +362,8 @@ func (fake *FakeConfig) MaxAllowedFailures() int {
 	fake.maxAllowedFailuresMutex.Unlock()
 	if fake.MaxAllowedFailuresStub != nil {
 		return fake.MaxAllowedFailuresStub()
-	} else {
-		return fake.maxAllowedFailuresReturns.result1
 	}
+	return fake.maxAllowedFailuresReturns.result1
 }
 
 func (fake *FakeConfig) MaxAllowedFailuresCallCount() int {
@@ -336,9 +386,8 @@ func (fake *FakeConfig) AppTypes() []config.AppDefinition {
 	fake.appTypesMutex.Unlock()
 	if fake.AppTypesStub != nil {
 		return fake.AppTypesStub()
-	} else {
-		return fake.appTypesReturns.result1
 	}
+	return fake.appTypesReturns.result1
 }
 
 func (fake *FakeConfig) AppTypesCallCount() int {
@@ -369,6 +418,10 @@ func (fake *FakeConfig) Invocations() map[string][][]interface{} {
 	defer fake.prefixMutex.RUnlock()
 	fake.domainMutex.RLock()
 	defer fake.domainMutex.RUnlock()
+	fake.useSSLMutex.RLock()
+	defer fake.useSSLMutex.RUnlock()
+	fake.skipVerifyCertificateMutex.RLock()
+	defer fake.skipVerifyCertificateMutex.RUnlock()
 	fake.outputFileMutex.RLock()
 	defer fake.outputFileMutex.RUnlock()
 	fake.timeoutMutex.RLock()

--- a/cedar/main.go
+++ b/cedar/main.go
@@ -14,17 +14,18 @@ import (
 )
 
 var (
-	domain = flag.String("domain", "", "app domain")
-
-	numBatches       = flag.Int("n", 1, "number of batches to seed")
-	maxInFlight      = flag.Int("k", 1, "max number of cf operations in flight")
-	maxPollingErrors = flag.Int("max-polling-errors", 1, "max number of curl failures")
-	tolerance        = flag.Float64("tolerance", 1.0, "fractional failure tolerance")
-	configFile       = flag.String("config", "config.json", "path to cedar config file")
-	outputFile       = flag.String("output", "output.json", "path to cedar metric results file")
-	appPayload       = flag.String("payload", "assets/temp-app", "directory containing the stress-app payload to push")
-	prefix           = flag.String("prefix", "cedarapp", "the naming prefix for cedar generated apps")
-	timeout          = flag.Duration("timeout", 30*time.Second, "time allowed for a push or start operation, golang duration")
+	domain                = flag.String("domain", "", "app domain")
+	useSSL                = flag.Bool("use-ssl", false, "whether to use https when curling app endpoints")
+	skipVerifyCertificate = flag.Bool("skip-verify-certificate", false, "whether to ignore invalid TLS certificates")
+	numBatches            = flag.Int("n", 1, "number of batches to seed")
+	maxInFlight           = flag.Int("k", 1, "max number of cf operations in flight")
+	maxPollingErrors      = flag.Int("max-polling-errors", 1, "max number of curl failures")
+	tolerance             = flag.Float64("tolerance", 1.0, "fractional failure tolerance")
+	configFile            = flag.String("config", "config.json", "path to cedar config file")
+	outputFile            = flag.String("output", "output.json", "path to cedar metric results file")
+	appPayload            = flag.String("payload", "assets/temp-app", "directory containing the stress-app payload to push")
+	prefix                = flag.String("prefix", "cedarapp", "the naming prefix for cedar generated apps")
+	timeout               = flag.Duration("timeout", 30*time.Second, "time allowed for a push or start operation, golang duration")
 )
 
 func main() {
@@ -59,6 +60,8 @@ func main() {
 		*configFile,
 		*outputFile,
 		*timeout,
+		*useSSL,
+		*skipVerifyCertificate,
 	)
 
 	if err != nil {

--- a/cedar/seeder/app_generator.go
+++ b/cedar/seeder/app_generator.go
@@ -32,7 +32,7 @@ func (a appGenerator) Apps(logger lager.Logger) []CfApp {
 			for j := 0; j < appDef.AppCount; j++ {
 				name := a.appName(appDef.AppNamePrefix, i, j)
 				logger.Info("generate-app", lager.Data{"appName": name})
-				seedApp, err := NewCfApp(name, a.config.Domain(), a.config.MaxPollingErrors(), appDef.ManifestPath)
+				seedApp, err := NewCfApp(name, a.config.Domain(), a.config.UseSSL(), a.config.MaxPollingErrors(), appDef.ManifestPath)
 				if err != nil {
 					logger.Error("failed-generating-app", err)
 					continue

--- a/cedar/seeder/app_generator_test.go
+++ b/cedar/seeder/app_generator_test.go
@@ -46,7 +46,7 @@ var _ = Describe("AppGenerator", func() {
 		})
 	})
 
-	Context("when an app prefix is porvided", func() {
+	Context("when an app prefix is provided", func() {
 		BeforeEach(func() {
 			cfg.PrefixReturns("cf-2016-08-16T1600")
 		})

--- a/cedar/seeder/cfapp_test.go
+++ b/cedar/seeder/cfapp_test.go
@@ -1,9 +1,9 @@
 package seeder_test
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
-	"net/http/httptest"
+	"regexp"
 	"time"
 
 	"code.cloudfoundry.org/diego-stress-tests/cedar/cli/fakes"
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/ghttp"
 )
 
 const (
@@ -24,7 +25,7 @@ var _ = Describe("Cfapp", func() {
 	var fakeClient fakes.FakeCFClient
 	var ctx context.Context
 	var err error
-	var server *httptest.Server
+	var server *ghttp.Server
 
 	BeforeEach(func() {
 		ctx, _ = context.WithCancel(
@@ -33,15 +34,14 @@ var _ = Describe("Cfapp", func() {
 				fakeLogger,
 			),
 		)
-		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(200)
-			fmt.Fprintln(w, ``)
-		}))
+		server = ghttp.NewServer()
 
 		fakeClient = fakes.FakeCFClient{}
 
-		cfApp, err = NewCfApp("test-app", "random-123-domain.com", 1, "test-manifest.yml")
-		(cfApp.(*CfApplication)).SetUrl(server.URL)
+		cfApp, err = NewCfApp("test-app", "random-123-domain.com", false, 1, "test-manifest.yml")
+
+		(cfApp.(*CfApplication)).SetUrl(server.URL())
+
 		Expect(cfApp).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -66,13 +66,73 @@ var _ = Describe("Cfapp", func() {
 	Context("When an app is started", func() {
 		BeforeEach(func() {
 			fakeClient.CfReturns([]byte{}, nil)
+
+			server.RouteToHandler("GET", regexp.MustCompile(".*"), func(resp http.ResponseWriter, req *http.Request) {
+				resp.WriteHeader(200)
+			})
 		})
 
-		It("should start successfully", func() {
-			err = cfApp.Start(fakeLogger, ctx, &fakeClient, timeout)
-			Expect(fakeLogger).To(gbytes.Say("start.started"))
+		It("should log a successful start", func() {
+			err = cfApp.Start(fakeLogger, ctx, &fakeClient, false, timeout)
+
 			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fakeLogger).To(gbytes.Say("start.started"))
 			Expect(fakeLogger).To(gbytes.Say("start.completed"))
+		})
+
+		It("should return error when starting failed", func() {
+			fakeClient.CfReturns(nil, errors.New("oops!"))
+
+			err = cfApp.Start(fakeLogger, ctx, &fakeClient, false, timeout)
+
+			Expect(err).To(HaveOccurred())
+			Expect(fakeLogger).To(gbytes.Say("start.failed-to-start"))
+		})
+
+		It("should curl the app url", func() {
+			err = cfApp.Start(fakeLogger, ctx, &fakeClient, false, timeout)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(server.ReceivedRequests()).To(HaveLen(1))
+		})
+
+	})
+
+	Context("When an app is not routable after starting", func() {
+		BeforeEach(func() {
+			server.RouteToHandler("GET", regexp.MustCompile(".*"), func(resp http.ResponseWriter, req *http.Request) {
+				resp.WriteHeader(404)
+			})
+		})
+
+		It("should not retry when it's not requested", func() {
+			maxFailedCurls := 0
+			cfApp, _ = NewCfApp("test-app", "random-123-domain.com", false, maxFailedCurls, "test-manifest.yml")
+			(cfApp.(*CfApplication)).SetUrl(server.URL())
+			err = cfApp.Start(fakeLogger, ctx, &fakeClient, false, timeout)
+
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeLogger).NotTo(gbytes.Say("curl.retrying-curl"))
+			Expect(fakeLogger).To(gbytes.Say("curl.failed-to-curl"))
+
+			Expect(server.ReceivedRequests()).To(HaveLen(maxFailedCurls + 1))
+		})
+
+		It("should retry curl when it's requested", func() {
+			maxFailedCurls := 2
+			cfApp, _ = NewCfApp("test-app", "random-123-domain.com", false, maxFailedCurls, "test-manifest.yml")
+			(cfApp.(*CfApplication)).SetUrl(server.URL())
+			err = cfApp.Start(fakeLogger, ctx, &fakeClient, false, timeout)
+
+			Expect(err).To(HaveOccurred())
+
+			Expect(fakeLogger).To(gbytes.Say("curl.retrying-curl"))
+			Expect(fakeLogger).To(gbytes.Say("curl.failed-to-curl"))
+			Expect(fakeLogger).To(gbytes.Say("start.failed-curling-app"))
+
+			Expect(server.ReceivedRequests()).To(HaveLen(maxFailedCurls + 1))
 		})
 	})
 
@@ -81,12 +141,34 @@ var _ = Describe("Cfapp", func() {
 			fakeClient.CfReturns([]byte("fake-guid"), nil)
 		})
 
-		It("should push successfully", func() {
+		It("should return the guid successfully", func() {
 			guid, err := cfApp.Guid(fakeLogger, ctx, &fakeClient, timeout)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(guid).To(Equal("fake-guid"))
 			Expect(fakeLogger).To(gbytes.Say("guid.started"))
 			Expect(fakeLogger).To(gbytes.Say("guid.completed"))
+		})
+	})
+
+	Context("When SSL is not required", func() {
+		BeforeEach(func() {
+			cfApp, err = NewCfApp("test-app", "random-123-domain.com", false, 1, "test-manifest.yml")
+		})
+
+		It("should use http in app url", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfApp.AppURL()).To(Equal("http://test-app.random-123-domain.com"))
+		})
+	})
+
+	Context("When SSL is required", func() {
+		BeforeEach(func() {
+			cfApp, err = NewCfApp("test-app", "random-123-domain.com", true, 1, "test-manifest.yml")
+		})
+
+		It("should use https in app url", func() {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfApp.AppURL()).To(Equal("https://test-app.random-123-domain.com"))
 		})
 	})
 })

--- a/cedar/seeder/deployer.go
+++ b/cedar/seeder/deployer.go
@@ -170,7 +170,7 @@ func (p *Deployer) StartApps(ctx context.Context, cancel context.CancelFunc) {
 				return
 			default:
 				startTime = time.Now()
-				err = appToStart.Start(logger, ctx, p.client, p.config.Timeout())
+				err = appToStart.Start(logger, ctx, p.client, p.config.SkipVerifyCertificate(), p.config.Timeout())
 				endTime = time.Now()
 			}
 

--- a/cedar/seeder/fakes/fake_cfapp.go
+++ b/cedar/seeder/fakes/fake_cfapp.go
@@ -36,13 +36,14 @@ type FakeCfApp struct {
 	pushReturns struct {
 		result1 error
 	}
-	StartStub        func(logger lager.Logger, ctx context.Context, client cli.CFClient, timeout time.Duration) error
+	StartStub        func(logger lager.Logger, ctx context.Context, client cli.CFClient, skipVerifyCertificate bool, timeout time.Duration) error
 	startMutex       sync.RWMutex
 	startArgsForCall []struct {
-		logger  lager.Logger
-		ctx     context.Context
-		client  cli.CFClient
-		timeout time.Duration
+		logger                lager.Logger
+		ctx                   context.Context
+		client                cli.CFClient
+		skipVerifyCertificate bool
+		timeout               time.Duration
 	}
 	startReturns struct {
 		result1 error
@@ -70,9 +71,8 @@ func (fake *FakeCfApp) AppName() string {
 	fake.appNameMutex.Unlock()
 	if fake.AppNameStub != nil {
 		return fake.AppNameStub()
-	} else {
-		return fake.appNameReturns.result1
 	}
+	return fake.appNameReturns.result1
 }
 
 func (fake *FakeCfApp) AppNameCallCount() int {
@@ -95,9 +95,8 @@ func (fake *FakeCfApp) AppURL() string {
 	fake.appURLMutex.Unlock()
 	if fake.AppURLStub != nil {
 		return fake.AppURLStub()
-	} else {
-		return fake.appURLReturns.result1
 	}
+	return fake.appURLReturns.result1
 }
 
 func (fake *FakeCfApp) AppURLCallCount() int {
@@ -126,9 +125,8 @@ func (fake *FakeCfApp) Push(logger lager.Logger, ctx context.Context, client cli
 	fake.pushMutex.Unlock()
 	if fake.PushStub != nil {
 		return fake.PushStub(logger, ctx, client, payload, timeout)
-	} else {
-		return fake.pushReturns.result1
 	}
+	return fake.pushReturns.result1
 }
 
 func (fake *FakeCfApp) PushCallCount() int {
@@ -150,21 +148,21 @@ func (fake *FakeCfApp) PushReturns(result1 error) {
 	}{result1}
 }
 
-func (fake *FakeCfApp) Start(logger lager.Logger, ctx context.Context, client cli.CFClient, timeout time.Duration) error {
+func (fake *FakeCfApp) Start(logger lager.Logger, ctx context.Context, client cli.CFClient, skipVerifyCertificate bool, timeout time.Duration) error {
 	fake.startMutex.Lock()
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
-		logger  lager.Logger
-		ctx     context.Context
-		client  cli.CFClient
-		timeout time.Duration
-	}{logger, ctx, client, timeout})
-	fake.recordInvocation("Start", []interface{}{logger, ctx, client, timeout})
+		logger                lager.Logger
+		ctx                   context.Context
+		client                cli.CFClient
+		skipVerifyCertificate bool
+		timeout               time.Duration
+	}{logger, ctx, client, skipVerifyCertificate, timeout})
+	fake.recordInvocation("Start", []interface{}{logger, ctx, client, skipVerifyCertificate, timeout})
 	fake.startMutex.Unlock()
 	if fake.StartStub != nil {
-		return fake.StartStub(logger, ctx, client, timeout)
-	} else {
-		return fake.startReturns.result1
+		return fake.StartStub(logger, ctx, client, skipVerifyCertificate, timeout)
 	}
+	return fake.startReturns.result1
 }
 
 func (fake *FakeCfApp) StartCallCount() int {
@@ -173,10 +171,10 @@ func (fake *FakeCfApp) StartCallCount() int {
 	return len(fake.startArgsForCall)
 }
 
-func (fake *FakeCfApp) StartArgsForCall(i int) (lager.Logger, context.Context, cli.CFClient, time.Duration) {
+func (fake *FakeCfApp) StartArgsForCall(i int) (lager.Logger, context.Context, cli.CFClient, bool, time.Duration) {
 	fake.startMutex.RLock()
 	defer fake.startMutex.RUnlock()
-	return fake.startArgsForCall[i].logger, fake.startArgsForCall[i].ctx, fake.startArgsForCall[i].client, fake.startArgsForCall[i].timeout
+	return fake.startArgsForCall[i].logger, fake.startArgsForCall[i].ctx, fake.startArgsForCall[i].client, fake.startArgsForCall[i].skipVerifyCertificate, fake.startArgsForCall[i].timeout
 }
 
 func (fake *FakeCfApp) StartReturns(result1 error) {
@@ -198,9 +196,8 @@ func (fake *FakeCfApp) Guid(logger lager.Logger, ctx context.Context, client cli
 	fake.guidMutex.Unlock()
 	if fake.GuidStub != nil {
 		return fake.GuidStub(logger, ctx, client, timeout)
-	} else {
-		return fake.guidReturns.result1, fake.guidReturns.result2
 	}
+	return fake.guidReturns.result1, fake.guidReturns.result2
 }
 
 func (fake *FakeCfApp) GuidCallCount() int {


### PR DESCRIPTION
In order to use cedar and arborist for stress tests in our test landscapes we need to

- always use https when curling apps, and
- skip the verification of certificates as they might be invalid in a test landscape.

Therefore, this change introduces the command line flags

- `useSSL` to cedar, and
- `skipVerifyCertificate` to both cedar and arborist

This adds support for different kind of (test) landscape setups.